### PR TITLE
Vert.x 3.0.0 updates

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.4</version>
+                <version>2.5.3</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 			</dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
-                <artifactId>vertx-apex</artifactId>
+                <artifactId>vertx-web</artifactId>
                 <version>${vertx.version}</version>
             </dependency>
             <dependency>
@@ -178,7 +178,7 @@
                 <version>2.7</version>
                 <configuration>
                     <aggregate>true</aggregate>
-                    <source>1.6</source>
+                    <source>1.8</source>
                     <encoding>UTF-8</encoding>
                     <maxmemory>1g</maxmemory>
                     <links>
@@ -270,7 +270,7 @@
         <source.property>1.8</source.property>
         <target.property>1.8</target.property>
         <atmosphere.version>2.3.4-SNAPSHOT</atmosphere.version>
-        <vertx.version>3.0.0-SNAPSHOT</vertx.version>
+        <vertx.version>3.0.0</vertx.version>
     </properties>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
 				<version>${vertx.version}</version>
 			</dependency>
             <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-apex</artifactId>
+                <version>${vertx.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.6.4</version>
@@ -262,10 +267,10 @@
     <properties>
         <distMgmtSnapshotsUrl>http://oss.sonatype.org/content/repositories/snapshots</distMgmtSnapshotsUrl>
         <surefire.redirectTestOutputToFile>false</surefire.redirectTestOutputToFile>
-        <source.property>1.7</source.property>
-        <target.property>1.7</target.property>
+        <source.property>1.8</source.property>
+        <target.property>1.8</target.property>
         <atmosphere.version>2.3.4-SNAPSHOT</atmosphere.version>
-        <vertx.version>2.1.5</vertx.version>
+        <vertx.version>3.0.0-SNAPSHOT</vertx.version>
     </properties>
 </project>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -28,7 +28,7 @@
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
-            <artifactId>vertx-platform</artifactId>
+            <artifactId>vertx-apex</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -79,7 +79,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.4</version>
+                <version>2.5.3</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -28,7 +28,7 @@
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
-            <artifactId>vertx-apex</artifactId>
+            <artifactId>vertx-web</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/server/src/main/java/org/atmosphere/vertx/AtmosphereCoordinator.java
+++ b/server/src/main/java/org/atmosphere/vertx/AtmosphereCoordinator.java
@@ -156,7 +156,9 @@ public class AtmosphereCoordinator {
      * Route the {@link ServerWebSocket} into the {@link AtmosphereFramework}
      *
      * @param webSocket the {@link ServerWebSocket}
+	 * @return the the {@link AtmosphereCoordinator}
      */
+
     public AtmosphereCoordinator route(ServerWebSocket webSocket) {
         Map<String, List<String>> paramMap = new QueryStringDecoder("?" + webSocket.query()).parameters();
         Map<String, String[]> params = new LinkedHashMap<String, String[]>(paramMap.size());
@@ -251,7 +253,8 @@ public class AtmosphereCoordinator {
     /**
      * Route an http request inside the {@link AtmosphereFramework}
      *
-     * @param request
+     * @param request the {@link HttpServerRequest}
+	 * @return the {@link AtmosphereCoordinator}
      */
     public AtmosphereCoordinator route(final HttpServerRequest request) {
         boolean async = false;

--- a/server/src/main/java/org/atmosphere/vertx/AtmosphereCoordinator.java
+++ b/server/src/main/java/org/atmosphere/vertx/AtmosphereCoordinator.java
@@ -34,12 +34,11 @@ import org.atmosphere.websocket.WebSocket;
 import org.atmosphere.websocket.WebSocketProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.vertx.java.core.Handler;
-import org.vertx.java.core.VoidHandler;
-import org.vertx.java.core.buffer.Buffer;
-import org.vertx.java.core.http.HttpServerRequest;
-import org.vertx.java.core.http.ServerWebSocket;
-
+import io.vertx.core.Handler;
+import io.vertx.core.VoidHandler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.ServerWebSocket;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -193,7 +192,7 @@ public class AtmosphereCoordinator {
             logger.debug("", e);
         }
 
-        webSocket.dataHandler(new Handler<Buffer>() {
+        webSocket.handler(new Handler<Buffer>() {
             @Override
             public void handle(Buffer data) {
                 webSocketProcessor.invokeWebSocketProtocol(w, data.toString());

--- a/server/src/main/java/org/atmosphere/vertx/AtmosphereUtils.java
+++ b/server/src/main/java/org/atmosphere/vertx/AtmosphereUtils.java
@@ -20,8 +20,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import org.atmosphere.cpr.AtmosphereRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.vertx.java.core.MultiMap;
-import org.vertx.java.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerRequest;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -39,7 +38,7 @@ public class AtmosphereUtils {
         if (request.headers().get("Content-Type") != null) {
             ct = request.headers().get("Content-Type");
         }
-        String method = request.method();
+        String method = request.method().name();
 
 
         URI uri = null;

--- a/server/src/main/java/org/atmosphere/vertx/VertxAsyncIOWriter.java
+++ b/server/src/main/java/org/atmosphere/vertx/VertxAsyncIOWriter.java
@@ -23,8 +23,8 @@ import org.atmosphere.cpr.AtmosphereResponse;
 import org.atmosphere.util.ByteArrayAsyncWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.vertx.java.core.http.HttpServerRequest;
-import org.vertx.java.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
 
 import java.io.IOException;
 import java.util.Map;

--- a/server/src/main/java/org/atmosphere/vertx/VertxAtmosphere.java
+++ b/server/src/main/java/org/atmosphere/vertx/VertxAtmosphere.java
@@ -16,7 +16,7 @@
 package org.atmosphere.vertx;
 
 import io.vertx.core.Vertx;
-import io.vertx.ext.apex.Router;
+import io.vertx.ext.web.Router;
 import org.atmosphere.cpr.AtmosphereInterceptor;
 import org.atmosphere.cpr.Broadcaster;
 import org.atmosphere.cpr.BroadcasterCache;
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.ServerWebSocket;
-import io.vertx.ext.apex.RoutingContext;
+import io.vertx.ext.web.RoutingContext;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/server/src/main/java/org/atmosphere/vertx/VertxAtmosphere.java
+++ b/server/src/main/java/org/atmosphere/vertx/VertxAtmosphere.java
@@ -37,7 +37,7 @@ import java.util.Map;
 
 /**
  * A boostrap class that can be used to bridge Atmosphere and Vert.x. As simple as
- * <pre><blockquote>
+ * <pre>
  public class VertxJerseyChat extends Verticle {
 
      private static final Logger logger = LoggerFactory.getLogger(VertxJerseyChat.class);
@@ -65,7 +65,7 @@ import java.util.Map;
          httpServer.listen(8080);
      }
  }
- * </blockquote></pre>
+ * </pre>
  * @author  Jeanfrancois Arcand
  */
 public class VertxAtmosphere {
@@ -93,7 +93,7 @@ public class VertxAtmosphere {
 
     /**
      * Return the bound @{link AtmosphereCoordinator}.
-     * @return @{link AtmosphereCoordinator}.
+     * @return the @{link AtmosphereCoordinator}.
      */
     public AtmosphereCoordinator coordinator() {
         return coordinator;
@@ -101,7 +101,7 @@ public class VertxAtmosphere {
 
     /**
      * Is the path match one of the resource deployed.
-     * @param path
+     * @param path the resource path.
      * @return boolean if true.
      */
     public boolean matchPath(String path) {
@@ -150,7 +150,7 @@ public class VertxAtmosphere {
          * {@link org.atmosphere.config.service.AtmosphereHandlerService}, {@link org.atmosphere.config.service.MeteorService},
          * {@link org.atmosphere.config.service.WebSocketHandlerService} and any Jersey resource.
          *
-         * @param resource
+         * @param resource the annotated resource Class.
          * @return this;
          */
         public Builder resource(Class<?> resource) {
@@ -218,7 +218,7 @@ public class VertxAtmosphere {
          * Add an {@link AtmosphereInterceptor}
          *
          * @param interceptor an {@link AtmosphereInterceptor}
-         * @return
+         * @return this
          */
         public Builder interceptor(AtmosphereInterceptor interceptor) {
             interceptors.add(interceptor);

--- a/server/src/main/java/org/atmosphere/vertx/VertxWebSocket.java
+++ b/server/src/main/java/org/atmosphere/vertx/VertxWebSocket.java
@@ -18,7 +18,9 @@ package org.atmosphere.vertx;
 import org.atmosphere.cpr.AtmosphereConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.vertx.java.core.http.ServerWebSocket;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.http.WebSocketFrame;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -44,7 +46,8 @@ public class VertxWebSocket extends org.atmosphere.websocket.WebSocket {
     @Override
     public org.atmosphere.websocket.WebSocket write(String data) throws IOException {
         logger.trace("WebSocket.write()");
-        webSocket.writeTextFrame(data);
+
+        webSocket.writeFrame(WebSocketFrame.textFrame(data, true));
         lastWrite = System.currentTimeMillis();
         return this;
     }
@@ -54,7 +57,9 @@ public class VertxWebSocket extends org.atmosphere.websocket.WebSocket {
      */
     @Override
     public org.atmosphere.websocket.WebSocket write(byte[] data, int offset, int length) throws IOException {
-        webSocket.writeTextFrame(new String(data, offset, length, "UTF-8"));
+        Buffer buf = Buffer.buffer().appendBytes(data, offset, length);
+
+        webSocket.writeFrame(WebSocketFrame.binaryFrame(buf, true));
         return this;
     }
 


### PR DESCRIPTION
Based on Bournas' fork using the 3.0.0-SNAPSHOT.  In addition to his tweaks, I made a few to get things functional with the vert.x 3.0.0 release build

* Updated vert.x references to use version 3.0.0 release
* References to vertx-apex -> vertx-web
* Java source/target updated to use 1.8
* A few minor javadoc tweaks to get javadoc to build without errors
